### PR TITLE
Make openaiModelMapper optional in the init process

### DIFF
--- a/azure/init.go
+++ b/azure/init.go
@@ -31,7 +31,7 @@ func Init() error {
 	apiVersion = viper.GetString(constant.ENV_AZURE_OPENAI_API_VER)
 	endpoint = viper.GetString(constant.ENV_AZURE_OPENAI_ENDPOINT)
 	openaiModelMapper = viper.GetString(constant.ENV_AZURE_OPENAI_MODEL_MAPPER)
-	if endpoint != "" && openaiModelMapper != "" {
+	if endpoint != "" {
 		if apiVersion == "" {
 			apiVersion = "2023-07-01-preview"
 		}


### PR DESCRIPTION
Modify the initialization condition in `azure/init.go` to allow the `openaiModelMapper` environment variable to be optional. This change facilitates configurations where the model mapper is not needed, and improving flexibility.

Resolves: #95