### PR TITLE
fix: add missing endpoint url path to request and make image non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ WORKDIR /app
 EXPOSE 8080
 COPY --from=builder /builder/bin .
 
+USER 1000:1000
+
 ENTRYPOINT ["/app/azure-openai-proxy"]

--- a/azure/model.go
+++ b/azure/model.go
@@ -42,7 +42,7 @@ func (c *StripPrefixConverter) Convert(req *http.Request, config *DeploymentConf
 	req.Host = config.EndpointUrl.Host
 	req.URL.Scheme = config.EndpointUrl.Scheme
 	req.URL.Host = config.EndpointUrl.Host
-	req.URL.Path = path.Join(fmt.Sprintf("/openai/deployments/%s", config.DeploymentName), strings.Replace(req.URL.Path, c.Prefix+"/", "/", 1))
+	req.URL.Path = path.Join(config.EndpointUrl.Path, fmt.Sprintf("/openai/deployments/%s", config.DeploymentName), strings.Replace(req.URL.Path, c.Prefix+"/", "/", 1))
 	req.URL.RawPath = req.URL.EscapedPath()
 
 	query := req.URL.Query()

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=v1.1.0
+VERSION=v1.3.10
 
 rm -rf bin
 
@@ -10,4 +10,4 @@ export GOOS=linux
 export GOARCH=amd64
 go build -trimpath -ldflags "-s -w" -o bin/azure-openai-proxy ./cmd
 
-docker build -t stulzq/azure-openai-proxy:$VERSION .
+docker buildx build --platform linux/amd64 -t stulzq/azure-openai-proxy:$VERSION .


### PR DESCRIPTION
Add missing relative path to request URL path.

The path to the azure API can be behing a URL that contains a relative prefix and not only just the host. Added the missing part to the request.

Also made the image run as non-root user, since it is not really needed to run as root and moreover in some contexts it is required to run images as non-root and is enforced by policies.

Upated the build script to use buildx instead